### PR TITLE
Support all Calliope mini boards

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -3,8 +3,7 @@
     "version": "1.0.3",
     "description": "",
     "dependencies": {
-        "core": "*",
-        "v1": "*"
+        "core": "*"
     },
     "files": [
         "main.blocks",


### PR DESCRIPTION
The dependiencies have the v1 package included, which limits the usage of this extension to Calliope mini 1 devices. This change removes the dependencies, so it could be used with all board versions.